### PR TITLE
BC break: move to 2 props, selectionOptions and selectionCallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 0.4.0 / 2016-??-??
 ==================
+- BREAKING CHANGE: all selection options are now part of a map, selectionOptions
+- selectIntermediates renamed "fillInGaps"
+- constantSelect renamed "constant"
+- preserveSelection renamed "preserve"
+- BREAKING CHANGE: all selection callbacks are now part of a map, selectionCallback
+- onSelectSlot renamed onSelectItem
 - fix #9: onSelectSlot called after selection finished and onFinishSelect already called
 - implement #7: by default, sort selectable items by DOM order
 - implement #3: add selectable types

--- a/build/Selection.js
+++ b/build/Selection.js
@@ -101,7 +101,7 @@ function makeSelectable(Component) {
           selectedValues: newvalues,
           containerBounds: this.bounds
         });
-        if (this.props.onSelectSlot && this.props.constantSelect) {
+        if (this.props.selectionCallbacks.onSelectItem && this.props.selectionOptions.constant) {
           (function () {
             var nodelist = Object.keys(newnodes).map(function (key) {
               return newnodes[key];
@@ -112,7 +112,7 @@ function makeSelectable(Component) {
               return newvalues[key];
             }).sort(sorter);
             if (_debug2.default.DEBUGGING.debug && _debug2.default.DEBUGGING.selection) {
-              _debug2.default.log('updatestate onSelectSlot', values, nodes, valuelist, nodelist, _this2.bounds);
+              _debug2.default.log('updatestate onSelectItem', values, nodes, valuelist, nodelist, _this2.bounds);
             }
             if (_this2.props.onSelectSlot) {
               _this2.props.onSelectSlot(values, function () {
@@ -127,7 +127,7 @@ function makeSelectable(Component) {
     }, {
       key: 'propagateFinishedSelect',
       value: function propagateFinishedSelect() {
-        if (!this.props.onFinishSelect) return;
+        if (!this.props.selectionCallbacks.onFinishSelect) return;
         var newnodes = this.state.selectedNodes;
         var newvalues = this.state.selectedValues;
         var nodelist = Object.keys(newnodes).map(function (key) {
@@ -181,7 +181,7 @@ function makeSelectable(Component) {
       value: function start(bounds, mouseDownData, selectionRectangle) {
         this.bounds = bounds;
         this.mouseDownData = mouseDownData;
-        if (this.props.constantSelect) {
+        if (this.props.selectionOptions.constant) {
           this.selectionManager.select(selectionRectangle, this.state, this.props);
         } else {
           this.selectionManager.deselect(this.state);
@@ -197,7 +197,7 @@ function makeSelectable(Component) {
     }, {
       key: 'end',
       value: function end(e, mouseDownData, selectionRectangle) {
-        if (this.props.constantSelect && !this.props.preserveSelection) {
+        if (this.props.selectionOptions.constant && !this.props.selectionOptions.preserve) {
           this.propagateFinishedSelect();
           this.selectionManager.deselect(this.state);
           return;
@@ -214,7 +214,7 @@ function makeSelectable(Component) {
           this.setState({ selecting: true });
         }
 
-        if (this.props.constantSelect) {
+        if (this.props.selectionOptions.constantSelect) {
           this.selectionManager.select(selectionRectangle, this.state, this.props);
         }
       }

--- a/examples/index.js
+++ b/examples/index.js
@@ -36,7 +36,7 @@ class Test extends React.Component {
 const Sel = Selection(Test)
 
 ReactDOM.render((
-  <Sel constantSelect selectable>
+  <Sel selectionOptions={{ constant: true, selectable: true }}>
     <SelectableThing thing="hi" index={1}/>
     <SelectableThing thing="there" index={2} />
     <SelectableThing thing="foo" index={3} />
@@ -92,7 +92,7 @@ const things = Array(50).fill(0).map(generateThing)
 const Sel2 = Selection(Test, (a, b) => Number(a) - Number(b))
 
 ReactDOM.render((
-  <Sel2 selectable constantSelect selectIntermediates style={{display: 'flex', flexFlow: 'row wrap', width: '100%'}}>
+  <Sel2 selectionOptions={{ selectable: true, constant: true, fillinGaps: true }} style={{display: 'flex', flexFlow: 'row wrap', width: '100%'}}>
     {things}
   </Sel2>
 ), document.getElementById('example2')
@@ -103,10 +103,12 @@ class Demo extends Component {
     super(props)
 
     this.state = {
-      constantSelect: false,
-      selectable: true,
-      preserveSelection: false,
-      selectIntermediates: false
+      selectionOptions: {
+        constant: false,
+        selectable: true,
+        preserve: false,
+        fillInGaps: false
+      },
     }
   }
 
@@ -115,11 +117,11 @@ class Demo extends Component {
       name = PropTypes.string.isRequired,
       checked = PropTypes.bool.isRequired
     }) => <div><label htmlFor={name}>{name} <input type="checkbox" value={checked} checked={checked} onChange={
-        () => this.setState({ [name]: !this.state[name] })
+        () => this.setState({ selectionOptions: { [name]: !this.state[name] } })
       }/></label></div>
     const ret = []
 
-    for (const name in this.state) {
+    for (const name in this.state.selectionOptions) {
       ret.push(<Checkbox name={name} checked={this.state[name]} />)
     }
     return ret

--- a/src/.stories/Selection.jsx
+++ b/src/.stories/Selection.jsx
@@ -75,9 +75,11 @@ storiesOf('module.Selectable', module)
   .add('selectable, constant select', () => {
     const Sel = Selection(Test)
     return (
-      <Sel constantSelect selectable
-           onFinishSelect={(...props) => console.log('finish', props)}
-           onSelectSlot={(...props) => console.log('slot', props)}
+      <Sel selectionOptions={{ constant: true, selectable: true }}
+           selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
       >
         <SelectableThing thing="hi" index={1}/>
         <SelectableThing thing="there" index={2} />
@@ -89,9 +91,11 @@ storiesOf('module.Selectable', module)
   .add('selectable, not constant select', () => {
     const Sel = Selection(Test)
     return (
-      <Sel selectable
-           onFinishSelect={(...props) => console.log('finish', props)}
-           onSelectSlot={(...props) => console.log('slot', props)}
+      <Sel selectionOptions={{selectable: true}}
+           selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
       >
         <SelectableThing thing="hi" index={1}/>
         <SelectableThing thing="there" index={2} />
@@ -104,8 +108,10 @@ storiesOf('module.Selectable', module)
     const Sel = Selection(Test)
     return (
       <Sel
-        onFinishSelect={(...props) => console.log('finish', props)}
-        onSelectSlot={(...props) => console.log('slot', props)}
+        selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
       >
         <SelectableThing thing="hi" index={1}/>
         <SelectableThing thing="there" index={2} />
@@ -117,9 +123,11 @@ storiesOf('module.Selectable', module)
   .add('selectable, constant select, preserve selection', () => {
     const Sel = Selection(Test)
     return (
-      <Sel constantSelect selectable preserveSelection
-           onFinishSelect={(...props) => console.log('finish', props)}
-           onSelectSlot={(...props) => console.log('slot', props)}
+      <Sel selectionOptions={{ constant: true, selectable: true, preserve: true }}
+           selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
       >
         <SelectableThing thing="hi" index={1}/>
         <SelectableThing thing="there" index={2} />
@@ -131,9 +139,11 @@ storiesOf('module.Selectable', module)
   .add('selectable, not constant select, preserve selection', () => {
     const Sel = Selection(Test)
     return (
-      <Sel selectable preserveSelection
-           onFinishSelect={(...props) => console.log('finish', props)}
-           onSelectSlot={(...props) => console.log('slot', props)}
+      <Sel selectionOptions={{ selectable: true, preserve: true }}
+           selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
       >
         <SelectableThing thing="hi" index={1}/>
         <SelectableThing thing="there" index={2} />
@@ -148,9 +158,11 @@ storiesOf('module.Selectable', module)
 
     const Sel = Selection(Test, (a, b) => Number(a) - Number(b))
     return (
-      <Sel selectable constantSelect selectIntermediates
-           onFinishSelect={(...props) => console.log('finish', props)}
-           onSelectSlot={(...props) => console.log('slot', props)}
+      <Sel selectionOptions={{ selectable: true, constant: true, fillInGaps: true }}
+           selectionCallbacks={{
+             onSelectItem: (...props) => console.log('item', props),
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
            style={{display: 'flex', flexFlow: 'row wrap', width: '50%'}}>
         {things}
       </Sel>
@@ -163,8 +175,10 @@ storiesOf('module.Selectable', module)
 
     const Sel = Selection(Test, (a, b) => Number(a) - Number(b))
     return (
-      <Sel selectable constantSelect
-           onFinishSelect={(...props) => console.log('finish', props)}
+      <Sel selectionOptions={{ selectable: true, constant: true }}
+           selectionCallbacks={{
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
            style={{display: 'flex', flexFlow: 'row wrap', width: '50%'}}>
         {things}
       </Sel>
@@ -178,8 +192,10 @@ storiesOf('module.Selectable', module)
 
     const Sel = Selection(Test, (a, b) => Number(a) - Number(b))
     return (
-      <Sel selectable constantSelect
-           onFinishSelect={(...props) => console.log('finish', props)}
+      <Sel selectionOptions={{ selectable: true, constant: true }}
+           selectionCallbacks={{
+             onFinishSelect: (...props) => console.log('finish', props)
+           }}
            style={{display: 'flex', flexFlow: 'row wrap', width: '50%'}}>
         {things}
       </Sel>

--- a/src/InputManager.js
+++ b/src/InputManager.js
@@ -52,7 +52,7 @@ export default class InputManager {
     const invalid = e && e.touches && e.touches.length > 1
       || e.which === 3
       || e.button === 2
-      || !this.component.props.selectable
+      || !this.component.props.selectionOptions.selectable
     return !invalid
   }
 

--- a/src/SelectionManager.js
+++ b/src/SelectionManager.js
@@ -132,7 +132,7 @@ export default class SelectionManager {
 
     this.sortedNodes.forEach(this.walkNodes.bind(this, { selectionRectangle, selectedIndices, changedNodes, props, findit, mouse }), this)
 
-    if (props.selectIntermediates) {
+    if (props.selectionOptions.fillInGaps) {
       const min = Math.min(...selectedIndices)
       const max = Math.max(...selectedIndices)
       const filled = Array.apply(min, Array(max - min)).map((x, y) => min + y + 1)

--- a/test/InputManager.test.js
+++ b/test/InputManager.test.js
@@ -26,7 +26,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -50,7 +52,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -91,7 +95,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -112,7 +118,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -137,7 +145,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: false
+          selectionOptions: {
+            selectable: false
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -157,7 +167,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -186,7 +198,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
     })
@@ -235,7 +249,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
     })
@@ -302,7 +318,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -324,7 +342,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -347,7 +367,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -378,7 +400,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -425,7 +449,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -468,7 +494,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -496,7 +524,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -516,7 +546,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -547,7 +579,9 @@ describe("InputManager", function() {
         },
         props: {
           clickTolerance: 2,
-          selectable: true
+          selectionOptions: {
+            selectable: true
+          }
         }
       }
       const manager = new InputManager(me, notify, me, findit, mouse)
@@ -568,7 +602,7 @@ describe("InputManager", function() {
                ref={(ref) => {
                  if (ref) {
                    manager = new InputManager(ref,
-                    notify, {props: { clickTolerance: 2, selectable: true } })
+                    notify, {props: { clickTolerance: 2, selectionOptions: { selectable: true } } })
                  }
                  this.ref = ref
                }}

--- a/test/Selection.test.js
+++ b/test/Selection.test.js
@@ -200,10 +200,12 @@ describe("Selection", () => {
       })
     })
 
-    it("should call onSelectSlot if constantSelect is enabled", () => {
+    it("should call onSelectItem if selectionOptions.constant is enabled", () => {
       const spy = sinon.spy()
       stuff = $((
-        <Thing selectable constantSelect onSelectSlot={spy}>
+        <Thing selectionOptions={{ selectable: true, constant: true }} selectionCallbacks={{
+          onSelectItem: spy
+        }}>
           <SelectableChild value="hi" key={1} />
           <SelectableChild value="hi2" key={2} />
           <SelectableChild value="hi3" key={3} />
@@ -256,10 +258,12 @@ describe("Selection", () => {
       ])
       expect(spy.args[0][4]).to.eql({hi: 'hi'})
     })
-    it("should not call onSelectSlot if constantSelection is disabled", () => {
+    it("should not call onSelectItem if selectionOptions.constant is disabled", () => {
       const spy = sinon.spy()
       stuff = $((
-        <Thing selectable onSelectSlot={spy}>
+        <Thing selectionOptions={{selectable: true}} selectionCallbacks={{
+          onSelectItem: spy
+        }}>
           <SelectableChild value="hi" key={1} />
           <SelectableChild value="hi2" key={2} />
           <SelectableChild value="hi3" key={3} />
@@ -298,7 +302,8 @@ describe("Selection", () => {
     beforeEach(() => {
       spy = sinon.spy()
       stuff = $((
-        <Thing selectable constantSelect onFinishSelect={spy}>
+        <Thing selectionOptions={{ selectable: true, constant: true }}
+               selectionCallbacks={{ onFinishSelect: spy }}>
         <SelectableChild value="hi" key={1}/>
         <SelectableChild value="hi2" key={2}/>
         <SelectableChild value="hi3" key={3}/>
@@ -402,8 +407,8 @@ describe("Selection", () => {
       spy = sinon.spy()
     })
 
-    it("should call select if constantSelect is active", () => {
-      stuff = $(<Thing constantSelect />).render()
+    it("should call select if selectionOptions.constant is active", () => {
+      stuff = $(<Thing selectionOptions={{ constant: true }} />).render()
 
       component = stuff[0]
 
@@ -413,7 +418,7 @@ describe("Selection", () => {
       expect(spy.called).to.be.true
     })
 
-    it("should call deselect if constantSelect is not active", () => {
+    it("should call deselect if selectionOptions.constant is not active", () => {
       stuff = $(<Thing />).render()
 
       component = stuff[0]
@@ -465,8 +470,8 @@ describe("Selection", () => {
   describe("end", () => {
     const Thing = Selection(Blah)
 
-    it("should call propagateFinishedSelect and deselect if constantSelect is on", () => {
-      const stuff = $(<Thing selectable constantSelect />).render()
+    it("should call propagateFinishedSelect and deselect if selectionOptions.constant is on", () => {
+      const stuff = $(<Thing selectionOptions={{ selectable: true, constant: true }} />).render()
       const component = stuff[0]
       component.propagateFinishedSelect = sinon.spy()
       component.selectionManager.deselect = sinon.spy()
@@ -475,6 +480,7 @@ describe("Selection", () => {
       expect(component.propagateFinishedSelect.called).to.be.true
       expect(component.selectionManager.deselect.called).to.be.true
     })
+
     it("should select any items in the selection rectangle, and propagateFinishedSelect", () => {
       const stuff = $(<Thing selectable />).render()
       const component = stuff[0]
@@ -502,8 +508,8 @@ describe("Selection", () => {
         selecting: true
       })
     })
-    it("should call select if constantSelect is enabled", () => {
-      const stuff = $(<Thing constantSelect />).render()
+    it("should call select if selectionOptions.constant is enabled", () => {
+      const stuff = $(<Thing selectionOptions={{ selectable: true, constant: true }} />).render()
       const component = stuff[0]
       component.selectionManager.select = sinon.spy()
 
@@ -590,10 +596,13 @@ describe("Selection", () => {
 
       component.props.should.eql({
         clickTolerance: 2,
-        constantSelect: false,
-        preserveSelection: false,
-        selectIntermediates: false,
-        selectable: false,
+        selectionOptions: {
+          selectable: false,
+          constant: false,
+          preserve: false,
+          fillInGaps: false
+        },
+        selectionCallbacks: {},
         selectedNodeList: [],
         selectedNodes: {},
         selectedValueList: [],

--- a/test/SelectionManager.test.js
+++ b/test/SelectionManager.test.js
@@ -433,7 +433,9 @@ describe("SelectionManager", function() {
     let node4
     beforeEach(() => {
       props = {
-        clickTolerance: 5
+        clickTolerance: 5,
+        selectionOptions: {},
+        selectionCallbacks: {}
       }
       manager = new SelectionManager(notify, props)
       node1 = {
@@ -495,8 +497,8 @@ describe("SelectionManager", function() {
       expect(notify.updateState.called).to.be.true
     })
 
-    it("should select 4 values with selectIntermediates", () => {
-      props.selectIntermediates = true
+    it("should select 4 values with fillInGaps", () => {
+      props.selectionOptions.fillInGaps = true
 
       manager.select({
         selectionRectangle: {sub: [1, 2, 4], x: 1, left: 2, y: 1, top: 2},
@@ -548,7 +550,9 @@ describe("SelectionManager", function() {
     let node4
     beforeEach(() => {
       props = {
-        clickTolerance: 5
+        clickTolerance: 5,
+        selectionOptions: {},
+        selectionCallbacks: {}
       }
       manager = new SelectionManager(notify, props)
       node1 = {


### PR DESCRIPTION
Consolidate props/callbacks.  Less chance of a prop collision with a child component, and allows extensibility easily